### PR TITLE
Modernize install.sh: strict shell, updated zinit, idempotent fontconfig symlink

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-sudo xbps-install -Suy &&
+set -euo pipefail
+
+sudo xbps-install -Syu &&
 sudo xbps-install -Sy xorg base-devel git curl wget libXft-devel libX11-devel harfbuzz-devel libXext-devel libXrender-devel libXinerama-devel bspwm sxhkd dunst flameshot htop neovim polybar python jq font-weather-icons font-awesome5 noto-fonts-cjk noto-fonts-emoji picom numlockx hsetroot firefox chrony lxappearance rofi gtk-engine-murrine gtk2-engines font-iosevka void-repo-multilib void-repo-multilib-nonfree void-repo-nonfree xtools zsh &&
 sudo ln -s /etc/sv/chronyd /var/service/ &&
 cp .zshrc ~ &&
@@ -9,9 +11,9 @@ cp .p10k.zsh ~ &&
 cp -r .config/ ~ &&
 cp -r .icons/ ~ &&
 cp -r .fonts/ ~ &&
-mkdir ~/.zinit &&
-git clone https://github.com/zdharma/zinit.git ~/.zinit/bin &&
-sudo ln -s /usr/share/fontconfig/conf.avail/70-no-bitmaps.conf /etc/fonts/conf.d/ &&
+mkdir -p ~/.zinit &&
+git clone https://github.com/zdharma-continuum/zinit.git ~/.zinit/bin &&
+sudo ln -sf /usr/share/fontconfig/conf.avail/70-no-bitmaps.conf /etc/fonts/conf.d/ &&
 sudo xbps-reconfigure -f fontconfig &&
 sudo fc-cache -f -v &&
 cd ~/Void-Linux-BSPWM/terminal &&


### PR DESCRIPTION
### Motivation
- Improve robustness of the installer by failing fast on errors and avoiding fragile assumptions about directories and commands.
- Replace an unmaintained `zinit` remote with the maintained `zdharma-continuum` fork.
- Make the fontconfig symlink and directory creation idempotent to avoid failures on repeated runs.

### Description
- Add `set -euo pipefail` to `install.sh` to enable strict shell error handling.
- Change `xbps-install -Suy` to `xbps-install -Syu` to keep update flags consistent and run the system update first via `sudo xbps-install -Syu`.
- Create the zinit folder with `mkdir -p ~/.zinit` and clone `https://github.com/zdharma-continuum/zinit.git` into `~/.zinit/bin` instead of the old repo.
- Make the fontconfig symlink idempotent by using `sudo ln -sf /usr/share/fontconfig/conf.avail/70-no-bitmaps.conf /etc/fonts/conf.d/`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969061600e8832c948326022f245e11)