### PR TITLE
Refresh installer: add PipeWire/XDG helpers, update zinit & fontconfig, fix bspwm rule

### DIFF
--- a/.config/bspwm/bspwmrc
+++ b/.config/bspwm/bspwmrc
@@ -37,7 +37,7 @@ bspc rule -a Viewnior state=floating
 bspc rule -a SMPlayer state=floating
 bspc rule -a mpv state=floating sticky=on rectangle=300x180+1060+475
 
-bscp rule -a polybar manage=off
+bspc rule -a polybar manage=off
 bspc rule -a Tint2 border=off manage=off layer=above state=floating
 bspc rule -a '*:Kunst' sticky=on layer=below border=off focus=off
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Run these commands in the terminal:
 2. After executing the script you should
 `sudo reboot`
 
+**Updates (Void Linux + bspwm, last 5 years)**
+1. Audio stack: modern Void Linux setups use PipeWire + WirePlumber. This installer now includes `pipewire`, `wireplumber`, `pipewire-pulse`, and `pavucontrol` to replace legacy PulseAudio flows.
+2. User directories and XDG helpers: add `xdg-user-dirs` and `xdg-utils` for better desktop integration (file managers, default apps, screenshots, etc.).
+
 
 **Aliases**  
 Configuration file - ~/.zshrc
@@ -145,6 +149,10 @@ Moving the floating window
 **Примечание**
 1. Ссылка для установки telegram темы - https://t.me/addtheme/kkbesp
 2. После выполнения скрипта выполнить перезагрузку `sudo reboot`  
+
+**Обновления (Void Linux + bspwm за последние 5 лет)**
+1. Аудио-стек: в современном Void Linux обычно используют PipeWire + WirePlumber. В установщик добавлены `pipewire`, `wireplumber`, `pipewire-pulse` и `pavucontrol` вместо старого PulseAudio.
+2. Пользовательские каталоги и XDG-утилиты: добавлены `xdg-user-dirs` и `xdg-utils` для лучшей интеграции с окружением.
 
 
 **Алиасы**  

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-sudo xbps-install -Suy &&
-sudo xbps-install -Sy xorg base-devel git curl wget libXft-devel libX11-devel harfbuzz-devel libXext-devel libXrender-devel libXinerama-devel bspwm sxhkd dunst flameshot htop neovim polybar python jq font-weather-icons font-awesome5 noto-fonts-cjk noto-fonts-emoji picom numlockx hsetroot firefox chrony lxappearance rofi gtk-engine-murrine gtk2-engines font-iosevka void-repo-multilib void-repo-multilib-nonfree void-repo-nonfree xtools zsh &&
+set -euo pipefail
+
+sudo xbps-install -Syu &&
+sudo xbps-install -Sy xorg base-devel git curl wget libXft-devel libX11-devel harfbuzz-devel libXext-devel libXrender-devel libXinerama-devel bspwm sxhkd dunst flameshot htop neovim polybar python jq font-weather-icons font-awesome5 noto-fonts-cjk noto-fonts-emoji picom numlockx hsetroot firefox chrony lxappearance rofi gtk-engine-murrine gtk2-engines font-iosevka void-repo-multilib void-repo-multilib-nonfree void-repo-nonfree xtools zsh pipewire wireplumber pipewire-alsa pipewire-pulse pavucontrol xdg-user-dirs xdg-utils &&
 sudo ln -s /etc/sv/chronyd /var/service/ &&
 cp .zshrc ~ &&
 cp .xinitrc ~ &&
@@ -9,9 +11,9 @@ cp .p10k.zsh ~ &&
 cp -r .config/ ~ &&
 cp -r .icons/ ~ &&
 cp -r .fonts/ ~ &&
-mkdir ~/.zinit &&
-git clone https://github.com/zdharma/zinit.git ~/.zinit/bin &&
-sudo ln -s /usr/share/fontconfig/conf.avail/70-no-bitmaps.conf /etc/fonts/conf.d/ &&
+mkdir -p ~/.zinit &&
+git clone https://github.com/zdharma-continuum/zinit.git ~/.zinit/bin &&
+sudo ln -sf /usr/share/fontconfig/conf.avail/70-no-bitmaps.conf /etc/fonts/conf.d/ &&
 sudo xbps-reconfigure -f fontconfig &&
 sudo fc-cache -f -v &&
 cd ~/Void-Linux-BSPWM/terminal &&


### PR DESCRIPTION
### Motivation
- Bring the installer and docs up-to-date for modern Void Linux desktop setups (PipeWire audio, XDG helpers, up-to-date zinit) and fix a user-visible bspwm typo.

### Description
- Add PipeWire and WirePlumber audio stack and GUI tools to the installer: `pipewire`, `wireplumber`, `pipewire-alsa`, `pipewire-pulse`, and `pavucontrol` in `install.sh`.
- Add desktop integration helpers `xdg-user-dirs` and `xdg-utils` to the installer and run `sudo xbps-install -Syu` with strict shell enabled via `set -euo pipefail`.
- Make zinit installation idempotent and use the maintained fork by creating `~/.zinit` with `mkdir -p` and cloning `https://github.com/zdharma-continuum/zinit.git` into `~/.zinit/bin`.
- Make the fontconfig symlink idempotent with `sudo ln -sf ...` and keep the fontconfig reconfigure/cache steps.
- Fix a typo in `.config/bspwm/bspwmrc` (`bscp` -> `bspc`) so the `polybar` rule applies, and document the Void/bspwm updates (English and Russian) in `README.md`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969061600e8832c948326022f245e11)